### PR TITLE
Fix default factory

### DIFF
--- a/diff_gaussian_rasterization/__init__.py
+++ b/diff_gaussian_rasterization/__init__.py
@@ -11,7 +11,7 @@
 
 import json
 import dacite
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from typing import NamedTuple
 import torch.nn as nn
 import torch
@@ -202,7 +202,7 @@ class SortQueueSizes:
 
 @dataclass
 class SortSettings:
-    queue_sizes : SortQueueSizes = SortQueueSizes()
+    queue_sizes : SortQueueSizes = field(default_factory=SortQueueSizes)
     sort_mode : SortMode = SortMode.GLOBAL
     sort_order : GlobalSortOrder = GlobalSortOrder.Z_DEPTH
     
@@ -225,8 +225,8 @@ class CullingSettings:
         
 @dataclass
 class ExtendedSettings:
-    sort_settings : SortSettings = SortSettings()
-    culling_settings : CullingSettings = CullingSettings()
+    sort_settings : SortSettings = field(default_factory=SortSettings)
+    culling_settings : CullingSettings = field(default_factory=CullingSettings)
     load_balancing : bool = False
     proper_ewa_scaling : bool = False
     def to_dict(self):


### PR DESCRIPTION
I was getting the following error
```
ValueError: mutable default <class 'diff_gaussian_rasterization.SortSettings'> for field sort_settings is not allowed: use default_factory
```
Which is easily solved by some small changes.